### PR TITLE
Add `data-original` as a possible source

### DIFF
--- a/jquery.jloupe.js
+++ b/jquery.jloupe.js
@@ -106,11 +106,12 @@ jQuery.fn.jloupe = function(o){
 	}
 		
 	$(this).each(function(){
-		var h = $(this).parent('a').attr('href');
-		var s = $(this).attr('src');
-		s = (h) ? h : s;
-		var i = $('<img />').attr('src', s);	
-		$(this).data('zoom',i);		
+		var dataOriginal = $(this).data("original");
+		var parentHref = $(this).parent('a').attr('href');
+		var src = $(this).attr('src');
+		var imageSource = dataOriginal || parentHref || src;
+		var imageElement = $('<img />').attr('src', imageSource);
+		$(this).data('zoom', imageElement);
 	})
 	.bind('mousemove', move_jLoupe)
 	.bind('mouseleave', start_jLoupe)


### PR DESCRIPTION
Although the parent href or the original src works in most cases, sometimes it's useful to specify a loupe image url. I've added the ability to set a `data-original` attribute.

What are your thoughts on this?
